### PR TITLE
Every function of the api is now a seperate operation.

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -4,7 +4,7 @@ on:
 jobs:
   formatting:
     runs-on: ubuntu-latest
-    container: node:21.5.0-alpine3.19
+    container: node:22.6.0-alpine3.19
     steps:
       - run: apk add make
       - uses: actions/checkout@v4
@@ -13,7 +13,7 @@ jobs:
 
   spelling:
     runs-on: ubuntu-latest
-    container: node:21.5.0-alpine3.19
+    container: node:22.6.0-alpine3.19
     steps:
       - run: apk add make
       - uses: actions/checkout@v4

--- a/.github/workflows/test-npm.yaml
+++ b/.github/workflows/test-npm.yaml
@@ -4,27 +4,18 @@ on:
 jobs:
   audit:
     runs-on: ubuntu-latest
-    container: node:21.5.0-alpine3.19
+    container: node:22.6.0-alpine3.19
     steps:
       - uses: actions/checkout@v4
       - run: npm ci
       - run: npm --workspaces audit --audit-level high
 
-  test-lts:
-    strategy:
-      matrix:
-        node-version: [18, 20, 22]
-        runs-on: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.runs-on }}
+  test:
+    runs-on: ubuntu-latest
+    container: node:22.6.0-alpine3.19
     steps:
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
       - run: corepack enable
 
       - uses: actions/checkout@v4
       - run: npm run initialize
-
-      # node test runner seems to support globs since v21
-      - if: ${{ matrix.node-version >= 21 }}
-        run: npm --workspaces test
+      - run: npm --workspaces test

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
         "packages/npm/*"
       ],
       "devDependencies": {
-        "@skiffa/generator": "^0.13.5",
-        "cspell": "^8.12.1",
+        "@skiffa/generator": "^0.13.6",
+        "cspell": "^8.13.1",
         "prettier": "^3.3.3"
       }
     },
@@ -19,13 +19,13 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "@skiffa/lib": "^0.12.1",
-        "@types/node": "^18.19.42",
+        "@skiffa/lib": "^0.12.2",
+        "@types/node": "^18.19.43",
         "goodrouter": "^2.1.6"
       },
       "devDependencies": {
         "@tsconfig/node18": "^18.2.4",
-        "rollup": "^4.19.1",
+        "rollup": "^4.20.0",
         "typescript": "^5.5.4"
       },
       "engines": {
@@ -36,13 +36,13 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "@skiffa/lib": "^0.12.1",
-        "@types/node": "^18.19.42",
+        "@skiffa/lib": "^0.12.2",
+        "@types/node": "^18.19.43",
         "goodrouter": "^2.1.6"
       },
       "devDependencies": {
         "@tsconfig/node18": "^18.2.4",
-        "rollup": "^4.19.1",
+        "rollup": "^4.20.0",
         "typescript": "^5.5.4"
       },
       "engines": {
@@ -50,16 +50,16 @@
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.12.1.tgz",
-      "integrity": "sha512-55wCxlKwRsYCt8uWB65C0xiJ4bP43UE3b/GK01ekyz2fZ11mudMWGMrX/pdKwGIOXFfFqDz3DCRxFs+fHS58oA==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.13.1.tgz",
+      "integrity": "sha512-ylAwnIdxBMJ9v6BHpFAQFZM+5zbybLtqVQJG7zQePts4e0/Qr2xjYFbC3F+fovZqyXPIx24BR+S6gFJNO1OdAw==",
       "dev": true,
       "dependencies": {
         "@cspell/dict-ada": "^4.0.2",
         "@cspell/dict-aws": "^4.0.3",
         "@cspell/dict-bash": "^4.1.3",
-        "@cspell/dict-companies": "^3.1.2",
-        "@cspell/dict-cpp": "^5.1.11",
+        "@cspell/dict-companies": "^3.1.3",
+        "@cspell/dict-cpp": "^5.1.12",
         "@cspell/dict-cryptocurrencies": "^5.0.0",
         "@cspell/dict-csharp": "^4.0.2",
         "@cspell/dict-css": "^4.0.12",
@@ -74,7 +74,7 @@
         "@cspell/dict-filetypes": "^3.0.4",
         "@cspell/dict-fonts": "^4.0.0",
         "@cspell/dict-fsharp": "^1.0.1",
-        "@cspell/dict-fullstack": "^3.1.8",
+        "@cspell/dict-fullstack": "^3.2.0",
         "@cspell/dict-gaming-terms": "^1.0.5",
         "@cspell/dict-git": "^3.0.0",
         "@cspell/dict-golang": "^6.0.9",
@@ -84,28 +84,28 @@
         "@cspell/dict-html-symbol-entities": "^4.0.0",
         "@cspell/dict-java": "^5.0.7",
         "@cspell/dict-julia": "^1.0.1",
-        "@cspell/dict-k8s": "^1.0.5",
+        "@cspell/dict-k8s": "^1.0.6",
         "@cspell/dict-latex": "^4.0.0",
         "@cspell/dict-lorem-ipsum": "^4.0.0",
         "@cspell/dict-lua": "^4.0.3",
         "@cspell/dict-makefile": "^1.0.0",
         "@cspell/dict-monkeyc": "^1.0.6",
         "@cspell/dict-node": "^5.0.1",
-        "@cspell/dict-npm": "^5.0.17",
+        "@cspell/dict-npm": "^5.0.18",
         "@cspell/dict-php": "^4.0.8",
         "@cspell/dict-powershell": "^5.0.5",
         "@cspell/dict-public-licenses": "^2.0.7",
-        "@cspell/dict-python": "^4.2.1",
+        "@cspell/dict-python": "^4.2.3",
         "@cspell/dict-r": "^2.0.1",
         "@cspell/dict-ruby": "^5.0.2",
-        "@cspell/dict-rust": "^4.0.4",
+        "@cspell/dict-rust": "^4.0.5",
         "@cspell/dict-scala": "^5.0.3",
-        "@cspell/dict-software-terms": "^4.0.0",
+        "@cspell/dict-software-terms": "^4.0.3",
         "@cspell/dict-sql": "^2.1.3",
         "@cspell/dict-svelte": "^1.0.2",
         "@cspell/dict-swift": "^2.0.1",
         "@cspell/dict-terraform": "^1.0.0",
-        "@cspell/dict-typescript": "^3.1.5",
+        "@cspell/dict-typescript": "^3.1.6",
         "@cspell/dict-vue": "^3.0.0"
       },
       "engines": {
@@ -113,30 +113,30 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.12.1.tgz",
-      "integrity": "sha512-nO/3GTk3rBpLRBzkmcKFxbtEDd3FKXfQ5uTCpJ27XYVHYjlU+d4McOYYMClMhpFianVol2JCyberpGAj6bVgLg==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.13.1.tgz",
+      "integrity": "sha512-vYZTBRkYjpNBifGNbYQsgIXesDEdUa9QAwllDcLZGKbhh5mY/C1ygPnAVpYDYiJNt1WCeIqW286DUyjRjkmHeA==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-types": "8.12.1"
+        "@cspell/cspell-types": "8.13.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.12.1.tgz",
-      "integrity": "sha512-lh0zIm43r/Fj3sQWXc68msKnXNrfPOo8VvzL1hOP0v/j2eH61fvELH08/K+nQJ8cCutNZ4zhk9+KMDU4KmsMtw==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.13.1.tgz",
+      "integrity": "sha512-acLWTQv3yWfeWXMds/cfQKZapslOrLHVL4VDp4rFyL/EnfgaCr7Ew9hQ7zAIARY3r/n0dByqWbOt2HKthdhx/g==",
       "dev": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.12.1.tgz",
-      "integrity": "sha512-3HE04m7DS/6xYpWPN2QBGCHr26pvxHa78xYk+PjiPD2Q49ceqTNdFcZOYd+Wba8HbRXSukchSLhrTujmPEzqpw==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.13.1.tgz",
+      "integrity": "sha512-EGdb7KLYCklV3sLxf/895b7s6sExh8DCHZFpDos2hjKwMt+F4ynsu1+ceybQtqoUF/MsyLoJXrrmPvV2uGVmUQ==",
       "dev": true,
       "dependencies": {
         "global-directory": "^4.0.1"
@@ -146,18 +146,18 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.12.1.tgz",
-      "integrity": "sha512-UQPddS38dQ/FG00y2wginCzdS6yxryiGrWXSD/P59idCrYYDCYnI9pPsx4u10tmRkW1zJ+O7gGCsXw7xa5DAJQ==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.13.1.tgz",
+      "integrity": "sha512-oLFJfxuB1rwGXn3eD5qSF9nf0lHu6YjO0JcrjWhAZQ0r3AsO97gsX50wwCFCw6szVU3rd1cTUktW0KYEZUY6dA==",
       "dev": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.12.1.tgz",
-      "integrity": "sha512-17POyyRgl7m7mMuv1qk2xX6E5bdT0F3247vloBCdUMyaVtmtN4uEiQ/jqU5vtW02vxlKjKS0HcTvKz4EVfSlzQ==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.13.1.tgz",
+      "integrity": "sha512-9dJdmyXLXJVesCJa/DWgwKsEC9p2RRFc6KORcLhNvtm1tE9TvCXiu5jV47sOmYXd6Hwan8IurBXXTz82CLVjPQ==",
       "dev": true,
       "engines": {
         "node": ">=18"
@@ -182,9 +182,9 @@
       "dev": true
     },
     "node_modules/@cspell/dict-companies": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.1.3.tgz",
-      "integrity": "sha512-qaAmfKtQLA7Sbe9zfFVpcwyG92cx6+EiWIpPURv11Ng2QMv2PKhYcterUJBooAvgqD0/qq+AsLN8MREloY5Mdw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.1.4.tgz",
+      "integrity": "sha512-y9e0amzEK36EiiKx3VAA+SHQJPpf2Qv5cCt5eTUSggpTkiFkCh6gRKQ97rVlrKh5GJrqinDwYIJtTsxuh2vy2Q==",
       "dev": true
     },
     "node_modules/@cspell/dict-cpp": {
@@ -254,9 +254,9 @@
       "dev": true
     },
     "node_modules/@cspell/dict-en-common-misspellings": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.0.3.tgz",
-      "integrity": "sha512-8nF1z9nUiSgMyikL66HTbDO7jCGtB24TxKBasXIBwkBKMDZgA2M883iXdeByy6m1JJUcCGFkSftVYp2W0bUgjw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.0.4.tgz",
+      "integrity": "sha512-lvOiRjV/FG4pAGZL3PN2GCVHSTCE92cwhfLGGkOsQtxSmef6WCHfHwp9auafkBlX0yFQSKDfq6/TlpQbjbJBtQ==",
       "dev": true
     },
     "node_modules/@cspell/dict-en-gb": {
@@ -410,9 +410,9 @@
       "dev": true
     },
     "node_modules/@cspell/dict-python": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.3.tgz",
-      "integrity": "sha512-C1CPX9wwEGgcHv/p7KfjuIOp1G6KNyx5gWYweAd6/KPv+ZpeM1v572zFUTmpO8WDuAfKFf00nqYL8/GmCENWBw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.4.tgz",
+      "integrity": "sha512-sCtLBqMreb+8zRW2bXvFsfSnRUVU6IFm4mT6Dc4xbz0YajprbaPPh/kOUTw5IJRP8Uh+FFb7Xp2iH03CNWRq/A==",
       "dev": true,
       "dependencies": {
         "@cspell/dict-data-science": "^2.0.1"
@@ -443,15 +443,15 @@
       "dev": true
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-4.0.3.tgz",
-      "integrity": "sha512-65QAVMc3YlcI7PcqWRY5ox53tTWC8aktUZdJYCVs4VDBPUCTSDnTSmSreeg4F5Z468clv9KF/S0PkxbLjgW72A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-4.0.5.tgz",
+      "integrity": "sha512-93knOtaQlWq1Zlz5LbjOl3P3hIiWbhd7kwGZPHVxCdD8+G3UEF9hivkpZ1miK/DzlV/Lcw2RoybOd91Xazc+dg==",
       "dev": true
     },
     "node_modules/@cspell/dict-sql": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.1.3.tgz",
-      "integrity": "sha512-SEyTNKJrjqD6PAzZ9WpdSu6P7wgdNtGV2RV8Kpuw1x6bV+YsSptuClYG+JSdRExBTE6LwIe1bTklejUp3ZP8TQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.1.5.tgz",
+      "integrity": "sha512-FmxanytHXss7GAWAXmgaxl3icTCW7YxlimyOSPNfm+njqeUDjw3kEv4mFNDDObBJv8Ec5AWCbUDkWIpkE3IpKg==",
       "dev": true
     },
     "node_modules/@cspell/dict-svelte": {
@@ -485,9 +485,9 @@
       "dev": true
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.12.1.tgz",
-      "integrity": "sha512-18faXHALiMsXtG3v67qeyDhNRZVtkhX5Je2qw8iZQB/i61y0Mfm22iiZeXsKImrXbwP0acyhRkRA1sp1NaQmOw==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.13.1.tgz",
+      "integrity": "sha512-jMqJHWmQy+in99JMSFlaGV9P033gCx7DCZvGO/ZSeZ2EatrUTanJk3oTG1TZknZydb0nnxr1mgTWXN7PCAAXDg==",
       "dev": true,
       "dependencies": {
         "import-meta-resolve": "^4.1.0"
@@ -497,18 +497,18 @@
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.12.1.tgz",
-      "integrity": "sha512-0O5qGHRXoKl0+hXGdelox2awrCMr8LXObUcWwYbSih7HIm4DwhxMO4qjDFye1NdjW0P88yhpQ23J2ceSto9C5Q==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.13.1.tgz",
+      "integrity": "sha512-ga1ibI9ZLJWNszfP7e6qQ8gnoQOP9rE/clALMAim9ssO6cmMhEEm+i1ROH4nsDfThd6sVlUJ0IOtx5dEqPmWxw==",
       "dev": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/url": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.12.1.tgz",
-      "integrity": "sha512-mUYaDniHVLw0YXn2egT2e21MYubMAf+1LDeC0kkbg4VWNxSlC1Ksyv6pqhos495esaa8OCjizdIdnGSF6al9Rw==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.13.1.tgz",
+      "integrity": "sha512-cCyojz5ovgGCexhez2urle4Q1UOEsp96lvl4pDmWNDHa/6n8dqiIn60SVzQIsAHzJ4yEV077RSaIrTlq/T+oSQ==",
       "dev": true,
       "engines": {
         "node": ">=18.0"
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/@jns42/generator/node_modules/@types/node": {
-      "version": "20.14.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.12.tgz",
-      "integrity": "sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==",
+      "version": "20.14.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.14.tgz",
+      "integrity": "sha512-d64f00982fS9YoOgJkAMolK7MN8Iq3TDdVjchbYHdEmjth/DHowx82GnoA+tVUAN+7vxfYUgAzi+JXbKNd2SDQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -639,9 +639,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.19.1.tgz",
-      "integrity": "sha512-XzqSg714++M+FXhHfXpS1tDnNZNpgxxuGZWlRG/jSj+VEPmZ0yg6jV4E0AL3uyBKxO8mO3xtOsP5mQ+XLfrlww==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.20.0.tgz",
+      "integrity": "sha512-TSpWzflCc4VGAUJZlPpgAJE1+V60MePDQnBd7PPkpuEmOy8i87aL6tinFGKBFKuEDikYpig72QzdT3QPYIi+oA==",
       "cpu": [
         "arm"
       ],
@@ -652,9 +652,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.19.1.tgz",
-      "integrity": "sha512-thFUbkHteM20BGShD6P08aungq4irbIZKUNbG70LN8RkO7YztcGPiKTTGZS7Kw+x5h8hOXs0i4OaHwFxlpQN6A==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.20.0.tgz",
+      "integrity": "sha512-u00Ro/nok7oGzVuh/FMYfNoGqxU5CPWz1mxV85S2w9LxHR8OoMQBuSk+3BKVIDYgkpeOET5yXkx90OYFc+ytpQ==",
       "cpu": [
         "arm64"
       ],
@@ -665,9 +665,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.19.1.tgz",
-      "integrity": "sha512-8o6eqeFZzVLia2hKPUZk4jdE3zW7LCcZr+MD18tXkgBBid3lssGVAYuox8x6YHoEPDdDa9ixTaStcmx88lio5Q==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.20.0.tgz",
+      "integrity": "sha512-uFVfvzvsdGtlSLuL0ZlvPJvl6ZmrH4CBwLGEFPe7hUmf7htGAN+aXo43R/V6LATyxlKVC/m6UsLb7jbG+LG39Q==",
       "cpu": [
         "arm64"
       ],
@@ -678,9 +678,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.19.1.tgz",
-      "integrity": "sha512-4T42heKsnbjkn7ovYiAdDVRRWZLU9Kmhdt6HafZxFcUdpjlBlxj4wDrt1yFWLk7G4+E+8p2C9tcmSu0KA6auGA==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.20.0.tgz",
+      "integrity": "sha512-xbrMDdlev53vNXexEa6l0LffojxhqDTBeL+VUxuuIXys4x6xyvbKq5XqTXBCEUA8ty8iEJblHvFaWRJTk/icAQ==",
       "cpu": [
         "x64"
       ],
@@ -691,9 +691,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.19.1.tgz",
-      "integrity": "sha512-MXg1xp+e5GhZ3Vit1gGEyoC+dyQUBy2JgVQ+3hUrD9wZMkUw/ywgkpK7oZgnB6kPpGrxJ41clkPPnsknuD6M2Q==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.20.0.tgz",
+      "integrity": "sha512-jMYvxZwGmoHFBTbr12Xc6wOdc2xA5tF5F2q6t7Rcfab68TT0n+r7dgawD4qhPEvasDsVpQi+MgDzj2faOLsZjA==",
       "cpu": [
         "arm"
       ],
@@ -704,9 +704,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.19.1.tgz",
-      "integrity": "sha512-DZNLwIY4ftPSRVkJEaxYkq7u2zel7aah57HESuNkUnz+3bZHxwkCUkrfS2IWC1sxK6F2QNIR0Qr/YXw7nkF3Pw==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.20.0.tgz",
+      "integrity": "sha512-1asSTl4HKuIHIB1GcdFHNNZhxAYEdqML/MW4QmPS4G0ivbEcBr1JKlFLKsIRqjSwOBkdItn3/ZDlyvZ/N6KPlw==",
       "cpu": [
         "arm"
       ],
@@ -717,9 +717,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.19.1.tgz",
-      "integrity": "sha512-C7evongnjyxdngSDRRSQv5GvyfISizgtk9RM+z2biV5kY6S/NF/wta7K+DanmktC5DkuaJQgoKGf7KUDmA7RUw==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.20.0.tgz",
+      "integrity": "sha512-COBb8Bkx56KldOYJfMf6wKeYJrtJ9vEgBRAOkfw6Ens0tnmzPqvlpjZiLgkhg6cA3DGzCmLmmd319pmHvKWWlQ==",
       "cpu": [
         "arm64"
       ],
@@ -730,9 +730,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.19.1.tgz",
-      "integrity": "sha512-89tFWqxfxLLHkAthAcrTs9etAoBFRduNfWdl2xUs/yLV+7XDrJ5yuXMHptNqf1Zw0UCA3cAutkAiAokYCkaPtw==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.20.0.tgz",
+      "integrity": "sha512-+it+mBSyMslVQa8wSPvBx53fYuZK/oLTu5RJoXogjk6x7Q7sz1GNRsXWjn6SwyJm8E/oMjNVwPhmNdIjwP135Q==",
       "cpu": [
         "arm64"
       ],
@@ -743,9 +743,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.19.1.tgz",
-      "integrity": "sha512-PromGeV50sq+YfaisG8W3fd+Cl6mnOOiNv2qKKqKCpiiEke2KiKVyDqG/Mb9GWKbYMHj5a01fq/qlUR28PFhCQ==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.20.0.tgz",
+      "integrity": "sha512-yAMvqhPfGKsAxHN8I4+jE0CpLWD8cv4z7CK7BMmhjDuz606Q2tFKkWRY8bHR9JQXYcoLfopo5TTqzxgPUjUMfw==",
       "cpu": [
         "ppc64"
       ],
@@ -756,9 +756,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.19.1.tgz",
-      "integrity": "sha512-/1BmHYh+iz0cNCP0oHCuF8CSiNj0JOGf0jRlSo3L/FAyZyG2rGBuKpkZVH9YF+x58r1jgWxvm1aRg3DHrLDt6A==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.20.0.tgz",
+      "integrity": "sha512-qmuxFpfmi/2SUkAw95TtNq/w/I7Gpjurx609OOOV7U4vhvUhBcftcmXwl3rqAek+ADBwSjIC4IVNLiszoj3dPA==",
       "cpu": [
         "riscv64"
       ],
@@ -769,9 +769,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.19.1.tgz",
-      "integrity": "sha512-0cYP5rGkQWRZKy9/HtsWVStLXzCF3cCBTRI+qRL8Z+wkYlqN7zrSYm6FuY5Kd5ysS5aH0q5lVgb/WbG4jqXN1Q==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.20.0.tgz",
+      "integrity": "sha512-I0BtGXddHSHjV1mqTNkgUZLnS3WtsqebAXv11D5BZE/gfw5KoyXSAXVqyJximQXNvNzUo4GKlCK/dIwXlz+jlg==",
       "cpu": [
         "s390x"
       ],
@@ -782,9 +782,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.19.1.tgz",
-      "integrity": "sha512-XUXeI9eM8rMP8aGvii/aOOiMvTs7xlCosq9xCjcqI9+5hBxtjDpD+7Abm1ZhVIFE1J2h2VIg0t2DX/gjespC2Q==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.20.0.tgz",
+      "integrity": "sha512-y+eoL2I3iphUg9tN9GB6ku1FA8kOfmF4oUEWhztDJ4KXJy1agk/9+pejOuZkNFhRwHAOxMsBPLbXPd6mJiCwew==",
       "cpu": [
         "x64"
       ],
@@ -795,9 +795,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.19.1.tgz",
-      "integrity": "sha512-V7cBw/cKXMfEVhpSvVZhC+iGifD6U1zJ4tbibjjN+Xi3blSXaj/rJynAkCFFQfoG6VZrAiP7uGVzL440Q6Me2Q==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.20.0.tgz",
+      "integrity": "sha512-hM3nhW40kBNYUkZb/r9k2FKK+/MnKglX7UYd4ZUy5DJs8/sMsIbqWK2piZtVGE3kcXVNj3B2IrUYROJMMCikNg==",
       "cpu": [
         "x64"
       ],
@@ -808,9 +808,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.19.1.tgz",
-      "integrity": "sha512-88brja2vldW/76jWATlBqHEoGjJLRnP0WOEKAUbMcXaAZnemNhlAHSyj4jIwMoP2T750LE9lblvD4e2jXleZsA==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.20.0.tgz",
+      "integrity": "sha512-psegMvP+Ik/Bg7QRJbv8w8PAytPA7Uo8fpFjXyCRHWm6Nt42L+JtoqH8eDQ5hRP7/XW2UiIriy1Z46jf0Oa1kA==",
       "cpu": [
         "arm64"
       ],
@@ -821,9 +821,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.19.1.tgz",
-      "integrity": "sha512-LdxxcqRVSXi6k6JUrTah1rHuaupoeuiv38du8Mt4r4IPer3kwlTo+RuvfE8KzZ/tL6BhaPlzJ3835i6CxrFIRQ==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.20.0.tgz",
+      "integrity": "sha512-GabekH3w4lgAJpVxkk7hUzUf2hICSQO0a/BLFA11/RMxQT92MabKAqyubzDZmMOC/hcJNlc+rrypzNzYl4Dx7A==",
       "cpu": [
         "ia32"
       ],
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.19.1.tgz",
-      "integrity": "sha512-2bIrL28PcK3YCqD9anGxDxamxdiJAxA+l7fWIwM5o8UqNy1t3d1NdAweO2XhA0KTDJ5aH1FsuiT5+7VhtHliXg==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.20.0.tgz",
+      "integrity": "sha512-aJ1EJSuTdGnM6qbVC4B5DSmozPTqIag9fSzXRNNo+humQLG89XpPgdt16Ia56ORD7s+H8Pmyx44uczDQ0yDzpg==",
       "cpu": [
         "x64"
       ],
@@ -856,17 +856,17 @@
       }
     },
     "node_modules/@skiffa/generator": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/@skiffa/generator/-/generator-0.13.5.tgz",
-      "integrity": "sha512-Wmz2akK1MdmoLZnllx5J2yx5U7BLcca105d7DrH01tpYJeq6wjzJNYVd3IOuoHbweNMH2RcYiTewta2hDlwkYA==",
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/@skiffa/generator/-/generator-0.13.6.tgz",
+      "integrity": "sha512-bYnvrE8FY6Ks8fOCpgo8C6JFWgmcxxX7U71CLHwh1iXP+tu57cSi26nqGcRTbyxliG+nEg4n5et6t2BmOwtYXg==",
       "dev": true,
       "dependencies": {
         "@jns42/core": "^0.7.9",
         "@jns42/generator": "^0.21.6",
         "@skiffa/core": "^0.2.3",
-        "@skiffa/lib": "^0.12.1",
-        "@types/node": "^18.19.42",
-        "@types/yargs": "^17.0.32",
+        "@skiffa/lib": "^0.12.2",
+        "@types/node": "^18.19.43",
+        "@types/yargs": "^17.0.33",
         "camelcase": "^8.0.0",
         "goodrouter": "^2.1.6",
         "tslib": "^2.6.3",
@@ -882,11 +882,11 @@
       }
     },
     "node_modules/@skiffa/lib": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@skiffa/lib/-/lib-0.12.1.tgz",
-      "integrity": "sha512-gPztmpe+ZBtNA7HlNNtMHvtPNVCvdPneUCKnIrDt101jyMc3rUQAovNTlX6DekrPw0dV5N3+gL4zc4dBhbGAug==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@skiffa/lib/-/lib-0.12.3.tgz",
+      "integrity": "sha512-xI0TpAXPi5A9Z4v41SdgpAVT03C91VK53IMqXjApYklyjVIhM3krDL/fhl2E4QjAFKbgDjuoBVXZq5RqRXVD5w==",
       "dependencies": {
-        "@types/node": "^18.19.42",
+        "@types/node": "^18.19.43",
         "js-base64": "^3.7.7",
         "msecs": "^1.0.3",
         "tslib": "^2.6.3",
@@ -909,9 +909,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.42.tgz",
-      "integrity": "sha512-d2ZFc/3lnK2YCYhos8iaNIYu9Vfhr92nHiyJHRltXWjXUBjEE+A4I58Tdbnw4VhggSW+2j5y5gTrLs4biNnubg==",
+      "version": "18.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.43.tgz",
+      "integrity": "sha512-Mw/YlgXnyJdEwLoFv2dpuJaDFriX+Pc+0qOBJ57jC1H6cDxIj2xc5yUrdtArDVG0m+KV6622a4p2tenEqB3C/g==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -923,9 +923,9 @@
       "dev": true
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.32",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -969,18 +969,6 @@
       "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
       "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
       "dev": true
-    },
-    "node_modules/atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "dev": true,
-      "bin": {
-        "atob": "bin/atob.js"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
-      }
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -1155,23 +1143,24 @@
       "dev": true
     },
     "node_modules/cspell": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.12.1.tgz",
-      "integrity": "sha512-mdnUUPydxxdj/uyF84U/DvPiY/l58Z2IpNwTx3H9Uve9dfT0vRv/7jiFNAvK4hAfZQaMaE7DPC00ckywTI/XgA==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.13.1.tgz",
+      "integrity": "sha512-Bqppilpwx9xt3jZPaYcqe1JPteNmfKhx9pw9YglZEePDUzdiJQNVIfs31589GAnXjgdqqctR8N87ffLcaBNPXw==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-json-reporter": "8.12.1",
-        "@cspell/cspell-pipe": "8.12.1",
-        "@cspell/cspell-types": "8.12.1",
-        "@cspell/dynamic-import": "8.12.1",
-        "@cspell/url": "8.12.1",
+        "@cspell/cspell-json-reporter": "8.13.1",
+        "@cspell/cspell-pipe": "8.13.1",
+        "@cspell/cspell-types": "8.13.1",
+        "@cspell/dynamic-import": "8.13.1",
+        "@cspell/url": "8.13.1",
         "chalk": "^5.3.0",
         "chalk-template": "^1.1.0",
         "commander": "^12.1.0",
-        "cspell-gitignore": "8.12.1",
-        "cspell-glob": "8.12.1",
-        "cspell-io": "8.12.1",
-        "cspell-lib": "8.12.1",
+        "cspell-dictionary": "8.13.1",
+        "cspell-gitignore": "8.13.1",
+        "cspell-glob": "8.13.1",
+        "cspell-io": "8.13.1",
+        "cspell-lib": "8.13.1",
         "fast-glob": "^3.3.2",
         "fast-json-stable-stringify": "^2.1.0",
         "file-entry-cache": "^9.0.0",
@@ -1191,44 +1180,43 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.12.1.tgz",
-      "integrity": "sha512-xEoKdb8hyturyiUXFdRgQotYegYe3OZS+Yc7JHnB75Ykt+Co2gtnu2M/Yb0yoqaHCXflVO6MITrKNaxricgqVw==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.13.1.tgz",
+      "integrity": "sha512-sXUFOyxvk+qDkoQdFkVEqj1hfQWzMi+tbi6ksiotQaqpm7r+YitZLSgwJjN4xgDO/rTLyP70k9fagdZ67MVZbw==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-types": "8.12.1",
+        "@cspell/cspell-types": "8.13.1",
         "comment-json": "^4.2.4",
-        "yaml": "^2.4.5"
+        "yaml": "^2.5.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.12.1.tgz",
-      "integrity": "sha512-jYHEA48on6pBQYVUEzXV63wy5Ulx/QNUZcoiG3C0OmYIKjACTaEg02AMDOr+Eaj34E5v4pGEShzot4Qtt/aiNQ==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.13.1.tgz",
+      "integrity": "sha512-Z0T4J4ahOJaHmWq83w24KXGik1zeauO5WvDRyzDyaSgpbA5MN2hN98LvxaIx72g3I+trtRK77XFcKginuME9EA==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "8.12.1",
-        "@cspell/cspell-types": "8.12.1",
-        "cspell-trie-lib": "8.12.1",
-        "fast-equals": "^5.0.1",
-        "gensequence": "^7.0.0"
+        "@cspell/cspell-pipe": "8.13.1",
+        "@cspell/cspell-types": "8.13.1",
+        "cspell-trie-lib": "8.13.1",
+        "fast-equals": "^5.0.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.12.1.tgz",
-      "integrity": "sha512-XlO87rdrab3VKU8e7+RGEfqEtYqo7ObgfZeYEAdJlwUXvqYxBzA11jDZAovDz/5jv0YfRMx6ch5t6+1zfSeBbQ==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.13.1.tgz",
+      "integrity": "sha512-XyZ3X5d6x0gkWtNXSAQRcPMG41bEdLx9cTgZCYCJhEZCesU1VpNm60F3oc11dMLkO+BqPH3An+AO/YEIiaje3A==",
       "dev": true,
       "dependencies": {
-        "@cspell/url": "8.12.1",
-        "cspell-glob": "8.12.1",
-        "cspell-io": "8.12.1",
+        "@cspell/url": "8.13.1",
+        "cspell-glob": "8.13.1",
+        "cspell-io": "8.13.1",
         "find-up-simple": "^1.0.0"
       },
       "bin": {
@@ -1239,12 +1227,12 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.12.1.tgz",
-      "integrity": "sha512-ZplEPLlNwj7luEKu/VudIaV+cGTQHExihGvAUxlIVMFURiAFMT5eH0UsQoCEpSevIEueO+slLUDy7rxwTwAGdQ==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.13.1.tgz",
+      "integrity": "sha512-rW1A3t7YvPXxcC4z1pp1m9coeWzUVUmRjUw3vMNGlEDC2zecB39KKbEqesziBqnBceNAY7O5itllIGFKr03vqA==",
       "dev": true,
       "dependencies": {
-        "@cspell/url": "8.12.1",
+        "@cspell/url": "8.13.1",
         "micromatch": "^4.0.7"
       },
       "engines": {
@@ -1252,13 +1240,13 @@
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.12.1.tgz",
-      "integrity": "sha512-IAES553M5nuB/wtiWYayDX2/5OmDu2VmEcnV6SXNze8oop0oodSqr3h46rLy+m1EOOD8nenMa295N/dRPqTB/g==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.13.1.tgz",
+      "integrity": "sha512-HUkd24bulvBwee1UNBurxGlPUOiywb9pB34iXXoxFWuloHohZ/DuFlE8B/31ZtjW48ffEYIu3QZfWhcnD8e81w==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "8.12.1",
-        "@cspell/cspell-types": "8.12.1"
+        "@cspell/cspell-pipe": "8.13.1",
+        "@cspell/cspell-types": "8.13.1"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -1268,45 +1256,45 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.12.1.tgz",
-      "integrity": "sha512-uPjYQP/OKmA8B1XbJunUTBingtrb6IKkp7enyljsZEbtPRKSudP16QPacgyZLLb5rCVQXyexebGfQ182jmq7dg==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.13.1.tgz",
+      "integrity": "sha512-t2sgZuWGBzPSOAStfvz/U3KoFEfDxEt1cXZj0Kd0Vs36v2uoLktm6ihMe7XNFu7zIdOFSajsYQ8Bi4RSLPGPxQ==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-service-bus": "8.12.1",
-        "@cspell/url": "8.12.1"
+        "@cspell/cspell-service-bus": "8.13.1",
+        "@cspell/url": "8.13.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.12.1.tgz",
-      "integrity": "sha512-z2aZXnrip76zbH0j0ibTGux3mA71TMHtoEAd+n66so7Tx3QydUDAI0u7tzfbP3JyqL9ZWPlclQAfbutMUuzMBQ==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.13.1.tgz",
+      "integrity": "sha512-H1HHG1pmATSeAaY0KmQ0xnkbSqJLvh9QpXWARDLWKUBvtE+/l44H4yVhIp/No3rM7PKMmb82GuSJzMaoIhHFLQ==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "8.12.1",
-        "@cspell/cspell-pipe": "8.12.1",
-        "@cspell/cspell-resolver": "8.12.1",
-        "@cspell/cspell-types": "8.12.1",
-        "@cspell/dynamic-import": "8.12.1",
-        "@cspell/strong-weak-map": "8.12.1",
-        "@cspell/url": "8.12.1",
+        "@cspell/cspell-bundled-dicts": "8.13.1",
+        "@cspell/cspell-pipe": "8.13.1",
+        "@cspell/cspell-resolver": "8.13.1",
+        "@cspell/cspell-types": "8.13.1",
+        "@cspell/dynamic-import": "8.13.1",
+        "@cspell/strong-weak-map": "8.13.1",
+        "@cspell/url": "8.13.1",
         "clear-module": "^4.1.2",
         "comment-json": "^4.2.4",
-        "cspell-config-lib": "8.12.1",
-        "cspell-dictionary": "8.12.1",
-        "cspell-glob": "8.12.1",
-        "cspell-grammar": "8.12.1",
-        "cspell-io": "8.12.1",
-        "cspell-trie-lib": "8.12.1",
+        "cspell-config-lib": "8.13.1",
+        "cspell-dictionary": "8.13.1",
+        "cspell-glob": "8.13.1",
+        "cspell-grammar": "8.13.1",
+        "cspell-io": "8.13.1",
+        "cspell-trie-lib": "8.13.1",
         "env-paths": "^3.0.0",
         "fast-equals": "^5.0.1",
         "gensequence": "^7.0.0",
         "import-fresh": "^3.3.0",
         "resolve-from": "^5.0.0",
-        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-languageserver-textdocument": "^1.0.12",
         "vscode-uri": "^3.0.8",
         "xdg-basedir": "^5.1.0"
       },
@@ -1315,26 +1303,17 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.12.1.tgz",
-      "integrity": "sha512-a9QmGGUhparM9v184YsB+D0lSdzVgWDlLFEBjVLQJyvp43HErZjvcTPUojUypNQUEjxvksX0/C4pO5Wq8YUD8w==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.13.1.tgz",
+      "integrity": "sha512-2moCsIYDmMT7hp5Non3CvWatfXptFWCuxjbXQGDNvWJ2Cj3oso/oBe4802GJv5GEenv9QBWmEtum/E7rFcx4JA==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "8.12.1",
-        "@cspell/cspell-types": "8.12.1",
+        "@cspell/cspell-pipe": "8.13.1",
+        "@cspell/cspell-types": "8.13.1",
         "gensequence": "^7.0.0"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/deepmerge": {
@@ -1589,9 +1568,9 @@
       }
     },
     "node_modules/goodrouter/node_modules/@types/node": {
-      "version": "20.14.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.12.tgz",
-      "integrity": "sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==",
+      "version": "20.14.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.14.tgz",
+      "integrity": "sha512-d64f00982fS9YoOgJkAMolK7MN8Iq3TDdVjchbYHdEmjth/DHowx82GnoA+tVUAN+7vxfYUgAzi+JXbKNd2SDQ==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1830,9 +1809,9 @@
       }
     },
     "node_modules/msecs/node_modules/@types/node": {
-      "version": "20.14.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.12.tgz",
-      "integrity": "sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==",
+      "version": "20.14.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.14.tgz",
+      "integrity": "sha512-d64f00982fS9YoOgJkAMolK7MN8Iq3TDdVjchbYHdEmjth/DHowx82GnoA+tVUAN+7vxfYUgAzi+JXbKNd2SDQ==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1965,9 +1944,9 @@
       "link": true
     },
     "node_modules/rollup": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.19.1.tgz",
-      "integrity": "sha512-K5vziVlg7hTpYfFBI+91zHBEMo6jafYXpkMlqZjg7/zhIG9iHqazBf4xz9AVdjS9BruRn280ROqLI7G3OFRIlw==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.20.0.tgz",
+      "integrity": "sha512-6rbWBChcnSGzIlXeIdNIZTopKYad8ZG8ajhl78lGRLsI2rX8IkaotQhVas2Ma+GPxJav19wrSzvRvuiv0YKzWw==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
@@ -1980,75 +1959,24 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.19.1",
-        "@rollup/rollup-android-arm64": "4.19.1",
-        "@rollup/rollup-darwin-arm64": "4.19.1",
-        "@rollup/rollup-darwin-x64": "4.19.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.19.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.19.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.19.1",
-        "@rollup/rollup-linux-arm64-musl": "4.19.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.19.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.19.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.19.1",
-        "@rollup/rollup-linux-x64-gnu": "4.19.1",
-        "@rollup/rollup-linux-x64-musl": "4.19.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.19.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.19.1",
-        "@rollup/rollup-win32-x64-msvc": "4.19.1",
+        "@rollup/rollup-android-arm-eabi": "4.20.0",
+        "@rollup/rollup-android-arm64": "4.20.0",
+        "@rollup/rollup-darwin-arm64": "4.20.0",
+        "@rollup/rollup-darwin-x64": "4.20.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.20.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.20.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.20.0",
+        "@rollup/rollup-linux-arm64-musl": "4.20.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.20.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.20.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.20.0",
+        "@rollup/rollup-linux-x64-gnu": "4.20.0",
+        "@rollup/rollup-linux-x64-musl": "4.20.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.20.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.20.0",
+        "@rollup/rollup-win32-x64-msvc": "4.20.0",
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/rollup-plugin-sourcemaps": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.6.3.tgz",
-      "integrity": "sha512-paFu+nT1xvuO1tPFYXGe+XnQvg4Hjqv/eIhG8i5EspfYYPBKL57X7iVbfv55aNVASg3dzWvES9dmWsL2KhfByw==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/pluginutils": "^3.0.9",
-        "source-map-resolve": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=10.0.0",
-        "rollup": ">=0.31.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/rollup-plugin-sourcemaps/node_modules/@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
-      }
-    },
-    "node_modules/rollup-plugin-sourcemaps/node_modules/@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true
-    },
-    "node_modules/rollup-plugin-sourcemaps/node_modules/estree-walker": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -2088,17 +2016,6 @@
     "node_modules/shared": {
       "resolved": "packages/npm/shared",
       "link": true
-    },
-    "node_modules/source-map-resolve": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
-      "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
-      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
-      "dev": true,
-      "dependencies": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0"
-      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -2217,9 +2134,9 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
-      "integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
       "dev": true
     },
     "node_modules/vscode-uri": {
@@ -2328,15 +2245,14 @@
     },
     "packages/npm/reverse": {
       "dependencies": {
-        "@types/node": "^18.19.42",
+        "@types/node": "^18.19.43",
         "reverse-api": "^0.1.0",
         "shared": "^0.1.0"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@tsconfig/node18": "^18.2.4",
-        "rollup": "^4.19.1",
-        "rollup-plugin-sourcemaps": "^0.6.3",
+        "rollup": "^4.20.0",
         "typescript": "^5.5.4"
       },
       "engines": {
@@ -2346,7 +2262,7 @@
     "packages/npm/shared": {
       "version": "0.1.0",
       "dependencies": {
-        "@types/node": "^18.19.42"
+        "@types/node": "^18.19.43"
       },
       "devDependencies": {
         "@tsconfig/node18": "^18.2.4",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "initialize": "node ./scripts/initialize.js"
   },
   "devDependencies": {
-    "@skiffa/generator": "^0.13.5",
-    "cspell": "^8.12.1",
+    "@skiffa/generator": "^0.13.6",
+    "cspell": "^8.13.1",
     "prettier": "^3.3.3"
   }
 }

--- a/packages/npm/reverse/package.json
+++ b/packages/npm/reverse/package.json
@@ -3,22 +3,21 @@
   "type": "module",
   "scripts": {
     "prepack": "node ./scripts/build.js",
-    "pretest": "node ./scripts/build.js",
+    "pretest": "tsc",
     "prestart": "node ./scripts/build.js",
     "start": "node transpiled/server.js",
     "build": "node ./scripts/build.js",
     "test": "node --test ./transpiled/**/*.test.js"
   },
   "dependencies": {
-    "@types/node": "^18.19.42",
+    "@types/node": "^18.19.43",
     "reverse-api": "^0.1.0",
     "shared": "^0.1.0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@tsconfig/node18": "^18.2.4",
-    "rollup": "^4.19.1",
-    "rollup-plugin-sourcemaps": "^0.6.3",
+    "rollup": "^4.20.0",
     "typescript": "^5.5.4"
   },
   "engines": {

--- a/packages/npm/reverse/package.json
+++ b/packages/npm/reverse/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "scripts": {
     "prepack": "node ./scripts/build.js",
-    "pretest": "tsc --build",
+    "pretest": "node ./scripts/build.js",
     "prestart": "node ./scripts/build.js",
     "start": "node transpiled/server.js",
     "build": "node ./scripts/build.js",

--- a/packages/npm/reverse/rollup.config.js
+++ b/packages/npm/reverse/rollup.config.js
@@ -14,7 +14,6 @@ export default defineConfig([
     plugins: [
       nodeResolve({
         browser: true,
-        mainFields: ["browser"],
       }),
     ],
   },

--- a/packages/npm/reverse/rollup.config.js
+++ b/packages/npm/reverse/rollup.config.js
@@ -12,6 +12,12 @@ export default defineConfig([
     input: path.resolve(projectRoot, "transpiled", "client.js"),
     output: { file: path.resolve("bundled", "client.js"), format: "iife", sourcemap: true },
     context: "window",
-    plugins: [sourcemaps(), nodeResolve()],
+    plugins: [
+      sourcemaps(),
+      nodeResolve({
+        browser: true,
+        mainFields: ["browser"],
+      }),
+    ],
   },
 ]);

--- a/packages/npm/reverse/rollup.config.js
+++ b/packages/npm/reverse/rollup.config.js
@@ -1,7 +1,6 @@
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import path from "path";
 import { defineConfig } from "rollup";
-import sourcemaps from "rollup-plugin-sourcemaps";
 import { fileURLToPath } from "url";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -13,7 +12,6 @@ export default defineConfig([
     output: { file: path.resolve("bundled", "client.js"), format: "iife", sourcemap: true },
     context: "window",
     plugins: [
-      sourcemaps(),
       nodeResolve({
         browser: true,
         mainFields: ["browser"],

--- a/packages/npm/shared/package.json
+++ b/packages/npm/shared/package.json
@@ -23,7 +23,7 @@
     "test": "node --test ./transpiled/**/*.test.js"
   },
   "dependencies": {
-    "@types/node": "^18.19.42"
+    "@types/node": "^18.19.43"
   },
   "devDependencies": {
     "@tsconfig/node18": "^18.2.4",

--- a/specifications/todo-api.yaml
+++ b/specifications/todo-api.yaml
@@ -29,7 +29,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/todo-item"
+              $ref: "#/components/schemas/todo-item-create"
       responses:
         "201":
           description: Created
@@ -39,7 +39,7 @@ paths:
                 $ref: "#/components/schemas/todo-item"
 
   /todo-items/{id}:
-    patch:
+    put:
       operationId: modify-todo-item
       description: Modify existing todo-item or mark as done
       parameters:
@@ -79,6 +79,27 @@ paths:
         "204":
           description: No Content
 
+  /todo-items/{id}/done:
+    post:
+      operationId: todo-item-set-done
+      description: >
+        Mark todo item as done
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the todo item
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/todo-item"
+
 components:
   schemas:
     todo-item:
@@ -98,18 +119,20 @@ components:
         done:
           type: boolean
 
-    todo-item-update:
+    todo-item-create:
       type: object
+      required:
+        - description
       properties:
-        id:
-          type: integer
-          format: int64
-          minimum: 1
         description:
           type: string
           minLength: 1
-        done:
-          type: boolean
-      oneOf:
-        - required: [id, description, done]
-        - required: [done]
+
+    todo-item-update:
+      type: object
+      required:
+        - description
+      properties:
+        description:
+          type: string
+          minLength: 1


### PR DESCRIPTION
This PR proposes a slightly different API specification based on the principle of every function that the api provides is an operation. Some notable changes are:

- Created a `todo-item-set-done` operation.
This operation will mark a todo-item as done. At first, this could be done via the `modify-todo-item` item. Because updating a todo-item is a different function than marking it as complete this makes more sense.

This is a functional way of looking at things. Another way to look at is would be to from a storage, or database perspective. From that angle it makes perfect sense to have an update operation that can be used to update any aspect of the todo item. However, our API provides functionality. The way data is stored should not be of influence to the api.

If this seperation (function and storage) is done correctly then we can change the way data is stored and it would be of no influence to the api design. The api would then only change if the function of the changes.

- A model for create, a model for update
These are the same models! This could be confusing! But, they have a different purpose. They are semantically different. They are not the same thing. For now this is not an advantage, but imagine if we want to add an extra field, that we only want to add when creating a todo item. Like if we wanted to add a field that says who created it. Then the created item sould be different from the updated item.

It would be good to make this thing a bit more DRY, but I'd use a different method for that, but that is a bit out of scope for this project.

This is, of course, nit picky, but in a bigger project this would be quite important.

- Changed put to patch
Simply because it's easier to work with. But there is much to say for both methods. This is more of a personal preference.

