### PR TITLE
use implicit types

### DIFF
--- a/packages/npm/todo/src/operation-handlers/todo.ts
+++ b/packages/npm/todo/src/operation-handlers/todo.ts
@@ -1,24 +1,18 @@
-import * as api from 'todo-api';
+import * as api from "todo-api";
 import { CommandHandlers } from "../commandHandlers/commandHandlers.js";
 import CreateTodo from "../commands/createTodo.js";
 
-
-type TodoItem = {
-  description: string;
-  id: number;
-  done: boolean;
-};
-
-export const addTodoOperationHandler: api.server.AddTodoItemOperationHandler<{}> = async (todo: any) => {
+export const addTodoOperationHandler: api.server.AddTodoItemOperationHandler<{}> = async (todo) => {
   const createTodoCommand = new CreateTodo(todo.description);
   const commandHandlers = new CommandHandlers();
 
   const createdTodo = await commandHandlers.createTodo(createTodoCommand);
 
-  const todoItem: TodoItem = {
+  const todoItem = {
     description: createdTodo.todoName,
     id: createdTodo.todoId,
     done: createdTodo.todoIsDone,
   };
+
   return todoItem;
 };


### PR DESCRIPTION
This PR uses types that are defined by the `api.server.AddTodoItemOperationHandler<{}>` type. This type defines the signature of the operation handler.  This handler is a function, the signature describes arguments and a return type.

So don't have to specify the arguments and the return type! This makes for less errors and that is of course one of the reasons why we use typescript.

